### PR TITLE
update package name as on npmjs.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Install 
 ```
-$ npm install --global aws-cw-annotate
+$ npm install --global aws-cloudwatch-annotations
 ```
 
 ## Usage


### PR DESCRIPTION
I noticed the given install command does not work because it does not match the [package name in the npm registry](https://www.npmjs.com/package/aws-cloudwatch-annotations).